### PR TITLE
Add test case for TCPReceiveBuffer; clarify instructions for Part 3

### DIFF
--- a/lab-tcp-reliable-transport/README.md
+++ b/lab-tcp-reliable-transport/README.md
@@ -633,7 +633,7 @@ In the file `mysocket.py`, flesh out the following sender-side methods for the
 
    This method is called after a loss event--either after a timeout (i.e., as
    scheduled by the timer) or a triple-duplicate ACK (i.e., discovered in
-   `handle_ack()`).
+   `handle_ack()`, see Part 4).
 
 In the file `mysocket.py`, flesh out the following receiver-side methods for
 the `TCPSocket` class.

--- a/lab-tcp-reliable-transport/test_buffer.py
+++ b/lab-tcp-reliable-transport/test_buffer.py
@@ -133,6 +133,13 @@ class TestBuffer(unittest.TestCase):
         self.assertEqual(buf.buffer,
                 {2033: b'mno'})
 
+        # make sure buffer does not accept data with seq number lower
+        # than base seq
+        buf.put(b'abc', 2021)
+        self.assertEqual(buf.base_seq, 2030)
+        self.assertEqual(buf.buffer,
+                {2033: b'mno'})
+
         # add missing data
         buf.put(b'jkl', 2030)
         self.assertEqual(buf.buffer,


### PR DESCRIPTION
This test case ensures that the `TCPReceiveBuffer` instance does not accept a piece of data with a sequence number lower than its current `base_seq`.

The change to README.md simply clarifies that Fast Retransmit is to be implemented in Part 4, not Part 3.